### PR TITLE
Fix indentation for install-cert-manager job in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 
 jobs:
- install-cert-manager:
+  install-cert-manager:
     runs-on: ubuntu-latest
     steps:
       - name: Set Kubernetes Context


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Tests
- [x] CI
- [ ] Documentation

## Sprint Stories

- URL to sprint story

## Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

## Evidences

Please include evidences of changes made in this pull request.
